### PR TITLE
Add config file for OpenOCD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-no
 # Programming
 Either:
 * Use the ST Micro ST-LINK utility (windows only it seems?), or
-* [stlink](https://github.com/texane/stlink) under Linux/OSX (though I haven't had much success with this yet...), or
+* [stlink](https://github.com/texane/stlink) under Linux/OSX (will need to be unlocked first), or
+* [OpenOCD](http://openocd.org) on Linux / RaspberryPi (see openocd_rs41.cfg file for usage) or
 * Use `flash.sh` with a [Black Magic Probe](https://1bitsquared.com/products/black-magic-probe). You will need to modify the path to the debugger's serial interface.
 
 Refer to [this file](./docs/programming_header.md) for programming header pinouts.

--- a/docs/programming_header.md
+++ b/docs/programming_header.md
@@ -11,7 +11,8 @@ Viewed into port from outside
 ---------------------------
 ```
 
-Suitable Plug: Molex 87568-1073  (element14 order code 1365756)
+Suitable Plug: Molex 87568-1073  (element14 order code 1365756)  
+Adafruit sell 2.54mm to 2mm patch leads (available from other resellers)
 
 * 1 - GND
 * 2 - I2C_SDA (PB11)
@@ -29,16 +30,18 @@ Suitable Plug: Molex 87568-1073  (element14 order code 1365756)
 ## STLink-v2 Header to Vaisala Cable
 ```
 RS41			STLink 
-----------------------
-1				4
+------------------------------
+1 or	 10	GND	4
 2		N/C
 3		N/C
-4				1
+4		POWER	1
 5		N/C
 6		N/C
-7				15
-8				9
-9				7
-10		N/C
+7		RESET	15
+8		CLOCK	9
+9		DATA	7
+10 or	1	GND	4
 ```
-All other pins on STLink header not connected.
+All other pins on STLink header not connected.  
+When using the Adafruit patch leads it is more convenient to use
+pin 10 as GND, since the 2mm ends are coupled as pairs.

--- a/openocd_rs41.cfg
+++ b/openocd_rs41.cfg
@@ -1,0 +1,50 @@
+# Copied and adapted from random internet sources.
+
+# Unlocking is not needed, but every 1k block of Flash Ram is write protected
+#  - see: http://openocd.org/doc/html/Flash-Commands.html#flashprotect
+
+# Typical usages:
+#	openocd -f ./openocd_rs41.cfg -c "init; halt; flash protect 0 0 20 off; exit"
+#						to unlock 20k of Flash for programming
+#	openocd -f ./openocd_rs41.cfg -c "program RS41HUP.elf verify reset exit"
+#						to program the connected rs41
+#	openocd -f ./openocd_rs41.cfg -c "init; reset; exit"
+#						will reset the connected rs41
+#
+
+# Normal use is with cheap STLINKv2 clone
+source [find interface/stlink-v2.cfg]
+# Alternative is to connect directly to a Raspberry Pi3
+# Find AdaFruit tutorial to build and run OpenOCD on RPi:
+#	source [find interface/raspberrypi2-native.cfg]
+#	bcm2835gpio_swd_nums 25 24
+#	bcm2835gpio_speed_coeffs 194938 48
+#	bcm2835gpio_srst_num 18
+#	reset_config srst_only srst_push_pull
+
+set WORKAREASIZE 0x2000
+
+# RS41 uses stm32f1 cortex m3
+source [find target/stm32f1x.cfg]
+
+# example script:
+proc RS41 {will_fail} {
+    init
+    sleep 200
+    reset
+    halt
+    wait_halt
+    stm32f1x unlock $will_fail
+    sleep 10
+    shutdown
+}
+
+#
+# Uncommon usage:
+#	openocd -f ./openocd_rs41.cfg -c "init; halt; stm32f1x options_read 0; exit"
+#						check setings before changing them
+#	openocd -f ./openocd_rs41.cfg -c "init; halt; stm32f1x unlock 0; exit"
+#						is not needed just to re-program RS41
+#	openocd -f ./openocd_rs41.cfg -c "RS41 0"
+#						to run a macro written above
+#


### PR DESCRIPTION
OpenOCD seems much nicer than Stlink, for Linux use, and should allow for direct connection from RaspberryPi GPIO pins, although I have not done that yet.